### PR TITLE
Add setting to toggle global hotkey hook

### DIFF
--- a/Forms/SettingsForm.Designer.cs
+++ b/Forms/SettingsForm.Designer.cs
@@ -45,6 +45,7 @@ namespace MusicBeePlugin.Forms
             this.lblArtistPreview = new System.Windows.Forms.Label();
             this.lblTrackPreview = new System.Windows.Forms.Label();
             this.btnInfo = new System.Windows.Forms.Button();
+            this.checkBoxHookGlobalHotkeys = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // lblAlbumFormat
@@ -155,11 +156,23 @@ namespace MusicBeePlugin.Forms
             this.btnInfo.UseVisualStyleBackColor = true;
             this.btnInfo.Click += new System.EventHandler(this.btnInfo_Click);
             // 
+            // checkBoxHookGlobalHotkeys
+            // 
+            this.checkBoxHookGlobalHotkeys.AutoSize = true;
+            this.checkBoxHookGlobalHotkeys.Location = new System.Drawing.Point(15, 135);
+            this.checkBoxHookGlobalHotkeys.Name = "checkBoxHookGlobalHotkeys";
+            this.checkBoxHookGlobalHotkeys.Size = new System.Drawing.Size(127, 17);
+            this.checkBoxHookGlobalHotkeys.TabIndex = 12;
+            this.checkBoxHookGlobalHotkeys.Text = "Hook Global Hotkeys";
+            this.checkBoxHookGlobalHotkeys.UseVisualStyleBackColor = true;
+            this.checkBoxHookGlobalHotkeys.CheckedChanged += new System.EventHandler(this.checkBoxHookGlobalHotkeys_CheckedChanged);
+            // 
             // SettingsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(384, 141);
+            this.ClientSize = new System.Drawing.Size(384, 158);
+            this.Controls.Add(this.checkBoxHookGlobalHotkeys);
             this.Controls.Add(this.btnInfo);
             this.Controls.Add(this.lblTrackPreview);
             this.Controls.Add(this.lblArtistPreview);
@@ -180,6 +193,7 @@ namespace MusicBeePlugin.Forms
             this.Shown += new System.EventHandler(this.SettingsForm_Shown);
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         private System.Windows.Forms.Button btnInfo;
@@ -200,5 +214,7 @@ namespace MusicBeePlugin.Forms
         private System.Windows.Forms.ToolTip toolTip;
 
         #endregion
+
+        private System.Windows.Forms.CheckBox checkBoxHookGlobalHotkeys;
     }
 }

--- a/Forms/SettingsForm.cs
+++ b/Forms/SettingsForm.cs
@@ -37,6 +37,7 @@ namespace MusicBeePlugin.Forms
             txtAlbumFormat.Text = settings.AlbumFormat;
             txtArtistFormat.Text = settings.ArtistFormat;
             txtTrackFormat.Text = settings.TrackFormat;
+            checkBoxHookGlobalHotkeys.Checked = settings.HookGlobalHotkeys;
         }
 
         private string GetFormattedPreview(string input)
@@ -84,6 +85,11 @@ namespace MusicBeePlugin.Forms
         private void OnFormatTextChanged(object sender, EventArgs e)
         {
             UpdatePreview();
+        }
+
+        private void checkBoxHookGlobalHotkeys_CheckedChanged(object sender, EventArgs e)
+        {
+            settings.HookGlobalHotkeys = checkBoxHookGlobalHotkeys.Checked;
         }
     }
 }

--- a/MediaControl.cs
+++ b/MediaControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Windows.Media;
 using Windows.Media.Playback;
 using Windows.Storage.Streams;
@@ -213,6 +213,11 @@ namespace MusicBeePlugin
 
         private void SystemMediaControls_ButtonPressed(SystemMediaTransportControls smtc, SystemMediaTransportControlsButtonPressedEventArgs args)
         {
+            if (!settings.HookGlobalHotkeys)
+            {
+                return;
+            }
+
             switch (args.Button)
             {
                 case SystemMediaTransportControlsButton.Stop:

--- a/Settings.cs
+++ b/Settings.cs
@@ -28,6 +28,9 @@ namespace MusicBeePlugin
         [DataMember]
         private string trackFormat;
 
+        [DataMember]
+        private bool hookGlobalHotkeys;
+
         public string AlbumFormat
         {
             get => albumFormat ?? defaults[nameof(AlbumFormat)];
@@ -44,6 +47,12 @@ namespace MusicBeePlugin
         {
             get => trackFormat ?? defaults[nameof(TrackFormat)];
             set => SetIfChanged(ref trackFormat, value);
+        }
+
+        public bool HookGlobalHotkeys
+        {
+            get => hookGlobalHotkeys;
+            set => SetIfChanged(ref hookGlobalHotkeys, value);
         }
 
         public bool IsDirty { get; private set; }

--- a/Settings.cs
+++ b/Settings.cs
@@ -29,7 +29,7 @@ namespace MusicBeePlugin
         private string trackFormat;
 
         [DataMember]
-        private bool hookGlobalHotkeys;
+        private bool hookGlobalHotkeys = true;
 
         public string AlbumFormat
         {


### PR DESCRIPTION
MusicBee already offers a way to set a hotkey to be global and this conflicts with it.

If the hotkey isn't set to global within MusicBee sometimes it doesn't have proper "focus" and the media keys won't work - however, when having them global and using the hook from this plugin, it will send a play and pause close to one another that the player breaks.

For context I have a dual PC streaming setup and use [InputDirector](https://www.inputdirector.com/) which allows me to connect the PCs together so I only need one keyboard and mouse. I then send over the media keys from one PC to the other, which is why I have to rely on the MusicBee global hotkey option instead of what this plugin implements.